### PR TITLE
Read inside temperature and humidity measured by 4 Thermo-hygro-sensors

### DIFF
--- a/mobilealerts/sensor.py
+++ b/mobilealerts/sensor.py
@@ -849,6 +849,8 @@ class Sensor:
             self[0]._set_boolean(packet[14:16], 0x8000)
             self[1]._set_door_window_time_span(packet[14:22])
         elif self._type_id == 0x11:
+            self[0]._set_temperature(packet[26:28], packet[42:44])
+            self[1]._set_humidity(packet[29], packet[45])
             self[2]._set_temperature(packet[14:16], packet[30:32])
             self[3]._set_humidity(packet[17], packet[33])
             self[4]._set_temperature(packet[18:20], packet[34:36])

--- a/tests/sensor/sensor_test.py
+++ b/tests/sensor/sensor_test.py
@@ -51,6 +51,18 @@ from mobilealerts import Sensor
             "ce5d8bcb801275ffffffffff4023128e0b04060000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
             "id: 75FFFFFFFFFF (battery good, last event: 2019-09-25 20:18:08)",
         ),
+        (
+            "ea63a5beaa2e111ec6ffb78900a400c1084300d6083c00d3083c00e8083400c1084400d6083d00d3083c40ea08341a00000000000000000000000000000000",
+            "id: 111EC6FFB789 (battery good, last seen: 2022-12-23 14:43:54)\n"
+            "Temperature: 23.2°C; previous: 23.4°C\n"
+            "Humidity: 52%; previous: 52%\n"
+            "External temperature 1: 19.3°C; previous: 19.3°C\n"
+            "External humidity 1: 67%; previous: 68%\n"
+            "External temperature 2: 21.4°C; previous: 21.4°C\n"
+            "External humidity 2: 60%; previous: 61%\n"
+            "External temperature 3: 21.1°C; previous: 21.1°C\n"
+            "External humidity 3: 60%; previous: 60%",
+        ),
     ],
 )
 def test_sensor(data: str, expected: str) -> None:


### PR DESCRIPTION
## Description

Inside temperature and humidity 4 Thermo-hygro-sensors is not set even though it is measured and reported by 
4 Thermo-hygro-sensors and sent with other data through the gateway.

This PR fixes this issue by adding necessary code and also adds a test case for 4 Thermo-hygro-sensors.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/PlusPlus-ua/python-mobilealerts/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/PlusPlus-ua/python-mobilealerts/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
